### PR TITLE
[SOMTE-417 | RFM] Add timestamps to logs & new sendStoredLogs() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const logger = new Logify<CustomErrorType>({
   },
   // Storage configuration
   storage?: {
-    key?: string,
+    key: 'logs',
     getItem: (key: string): string | null => logsStorage.getString(key) ?? null,
     setItem: (key: string, value: string) => logsStorage.set(key, value),
   }

--- a/README.md
+++ b/README.md
@@ -28,29 +28,29 @@ export const logsStorage = new MMKV({ id: 'logs' })
 const logger = new Logify<CustomErrorType>({
   endpoint: 'http://some-endpoint.com',
   // Can be an object or a function, get's added to each log
-  defaultParams?: {
-    userId: getUserId()
+  defaultParams: {
+    userId: getUserId(),
     source: 'app'
   },
   // Error here has CustomErrorType | DefaultErrorType(from lib), can parse error to be something useful
-  parseError?: (error) => {
+  parseError: (error) => {
     // do stuff with error
     return parsedErrorMessage
   },
   // Condition if logs should be sent to server. Can be a function. Defaults to true
-  shouldSendLogsIf?: !__DEV__,
+  shouldSendLogsIf: !__DEV__,
   // Condition if logs should be shown in console. Can be a function. Defaults to true
-  shouldLogToConsoleIf?: true,
+  shouldLogToConsoleIf: true,
   // Possibility to edit colors that are printed to console
-  printColors?: {
-    debug?: string,
-    info?: string,
-    warn?: string,
-    error?: string,
-    fatal?: string,
+  printColors: {
+    debug: '#FFFFFF',
+    info: '#ADD8E6',
+    warn: '#FFA500',
+    error: '#FF0000',
+    fatal: '#FF0000',
   },
   // Storage configuration
-  storage?: {
+  storage: {
     key: 'logs',
     getItem: (key: string): string | null => logsStorage.getString(key) ?? null,
     setItem: (key: string, value: string) => logsStorage.set(key, value),

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ export const logsStorage = new MMKV({ id: 'logs' })
 
 const logger = new Logify<CustomErrorType>({
   endpoint: 'http://some-endpoint.com',
-  // Storage key. Will fall back to "logs" by default
-  storageKey: 'logs-storage',
   // Can be an object or a function, get's added to each log
   defaultParams?: {
     userId: getUserId()
@@ -53,6 +51,7 @@ const logger = new Logify<CustomErrorType>({
   },
   // Storage configuration
   storage?: {
+    key?: string,
     getItem: (key: string): string | null => logsStorage.getString(key) ?? null,
     setItem: (key: string, value: string) => logsStorage.set(key, value),
   }

--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@
 ```typescript
 // core/logging-core.ts
 
+import { MMKV } from 'react-native-mmkv'
 import Logify from '@colorfy-software/logify'
 
 interface CustomErrorType {
   message: string
   code: number
 }
+
+export const logsStorage = new MMKV({ id: 'logs' })
 
 const logger = new Logify<CustomErrorType>({
   endpoint: 'http://some-endpoint.com',
@@ -45,6 +48,12 @@ const logger = new Logify<CustomErrorType>({
     warn?: string,
     error?: string,
     fatal?: string,
+  },
+  // Storage configuration
+  storage?: {
+    key: 'logs',
+    get: (key: string): string | null => logsStorage.getString(key) ?? null,
+    set: (key: string, value: string) => logsStorage.set(key, value),
   }
 })
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ export const logsStorage = new MMKV({ id: 'logs' })
 
 const logger = new Logify<CustomErrorType>({
   endpoint: 'http://some-endpoint.com',
+  // Storage key. Will fall back to "logs" by default
+  storageKey: 'logs-storage',
   // Can be an object or a function, get's added to each log
   defaultParams?: {
     userId: getUserId()
@@ -51,9 +53,8 @@ const logger = new Logify<CustomErrorType>({
   },
   // Storage configuration
   storage?: {
-    key: 'logs',
-    get: (key: string): string | null => logsStorage.getString(key) ?? null,
-    set: (key: string, value: string) => logsStorage.set(key, value),
+    getItem: (key: string): string | null => logsStorage.getString(key) ?? null,
+    setItem: (key: string, value: string) => logsStorage.set(key, value),
   }
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -321,7 +321,7 @@ class Logify<ErrorTypes = ErrorParamType> {
   }
 
   /**
-   * Stores an event (due to auth token missing or no network connection) to be sent to Grafana later, using "logStored" function.
+   * Stores an event (due to auth token missing or no network connection) to be sent to Grafana later, using "sendStoredLogs" function.
    * @param log `string` - JSON.stringify-ed log object
    * @private
    */
@@ -339,7 +339,7 @@ class Logify<ErrorTypes = ErrorParamType> {
   /**
    * Sends out all stored logs to Grafana.
    */
-  public logStored = (): void => {
+  public sendStoredLogs = (): void => {
     if (!this.props.storage) {
       return
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,27 +186,20 @@ class Logify<ErrorTypes = ErrorParamType> {
    * @private
    */
   private _sendLogToGrafana = async (log: string) => {
-    const hasLogicToSend = isBoolean(this.props.shouldSendLogsIf) || isFunction(this.props.shouldSendLogsIf)
+    const shouldSend = (): boolean => {
+      const hasLogicToSend = isBoolean(this.props.shouldSendLogsIf) || isFunction(this.props.shouldSendLogsIf)
 
-    if (hasLogicToSend) {
-      const shouldSend = isBoolean(this.props.shouldSendLogsIf)
+      if (!hasLogicToSend) {
+        return true
+      }
+
+      return isBoolean(this.props.shouldSendLogsIf)
         ? this.props.shouldSendLogsIf
         : // @ts-ignore
-          this.props?.shouldSendLogsIf?.()
+        this.props?.shouldSendLogsIf?.()
+    }
 
-      if (shouldSend) {
-        fetch(this.props.endpoint, {
-          method: 'POST',
-          body: log,
-          headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-          },
-        }).catch(e => {
-          this.debug('error sending log', e as Record<string, unknown>)
-          this._store(log)
-        })
-      }
-    } else {
+    if (shouldSend()) {
       fetch(this.props.endpoint, {
         method: 'POST',
         body: log,


### PR DESCRIPTION
This PR implements:
- Store failed logs + enable sending stored logs using batch mode; Add timestamp field to all logs
- Improve code
- Rename logStored to sendStoredLogs
- Improve code
- Add support for async storage.getItem and storage.setItem functions
- Improve code
- Fix README example